### PR TITLE
Add ArrayBuffer to url input

### DIFF
--- a/packages/core/PDFSlick.ts
+++ b/packages/core/PDFSlick.ts
@@ -79,7 +79,7 @@ export class PDFSlick {
   #viewerContainer: HTMLDivElement | undefined;
   #thumbsContainer: HTMLDivElement | undefined;
   printService: any;
-  url: string | URL | undefined;
+  url: string | ArrayBuffer | undefined;
   eventBus: EventBus;
   linkService: PDFLinkService;
   downloadManager: DownloadManager | null = null;
@@ -219,23 +219,27 @@ export class PDFSlick {
     this.store.setState({ scaleValue });
   }
 
-  async loadDocument(url: string | URL, options?: { filename?: string }) {
-    if (this.url) {
+  async loadDocument(url: string | URL | ArrayBuffer, options?: { filename?: string }) {
+    if (this.url && typeof this.url === "string") {
       try {
-        URL.revokeObjectURL(this.url.toString());
+        URL.revokeObjectURL(this.url);
       } catch (err) {}
     }
 
     this.document?.destroy();
     this.viewer?.cleanup();
 
-    this.url = url.toString();
+    if (url instanceof URL) {
+      this.url = url.toString();
+    } else {
+      this.url = url;
+    }
 
     const filename =
       options?.filename ?? getPdfFilenameFromUrl(this.url?.toString());
     this.filename = filename;
 
-    const pdfDocument = await getDocument({ url }).promise;
+    const pdfDocument = await getDocument(url).promise;
 
     this.document = pdfDocument;
     this.viewer.setDocument(this.document);

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -36,7 +36,7 @@ export type PDFSlickStateProps = {
   scrollMode: number;
 
   // documentInfo
-  url: string | null;
+  url: string | ArrayBuffer | null;
   filename?: string;
   filesize?: number;
   title?: string;

--- a/packages/solid/usePDFSlick.tsx
+++ b/packages/solid/usePDFSlick.tsx
@@ -8,7 +8,7 @@ import PDFSlickViewer from "./PDFSlickViewer";
 import { PDFSlickThumbnails } from "./PDFSlickThumbnails";
 
 type TUsePDFSlick = (
-  url: string | URL | undefined,
+  url: string | URL | ArrayBuffer | undefined,
   options?: PDFSlickOptions
 ) => {
   isDocumentLoaded: Accessor<boolean>;


### PR DESCRIPTION
Hi,
cool project!

I added `ArrayBuffer` as an input type together with `string` and `URL`. This is supported by pdfjs.
In my use case, I already have a blob downloaded, so it's easier for me to pass that to this library than a URL.

Apart from types, this PR just adds a check to verify the type is an `URL` before converting to string. This way if the input is an `ArrayBuffer` it is sent to pdfjs as it is.

What do you think? Can this be useful?