### PR TITLE
solidjs - error type is Accessor

### DIFF
--- a/packages/solid/usePDFSlick.tsx
+++ b/packages/solid/usePDFSlick.tsx
@@ -22,7 +22,7 @@ type TUsePDFSlick = (
   pdfSlickStore: PDFSlickState;
   PDFSlickViewer: typeof PDFSlickViewer;
   PDFSlickThumbnails: typeof PDFSlickThumbnails;
-  error: PDFException | null;
+  error: Accessor<PDFException | null>;
 };
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never;


### PR DESCRIPTION
Definition of TUsePDFSlick was invalid - error should be an Accessor.