### PR TITLE
Enable tracking load progress

### DIFF
--- a/packages/core/PDFSlick.ts
+++ b/packages/core/PDFSlick.ts
@@ -262,10 +262,12 @@ export class PDFSlick {
                 options?.filename ?? getPdfFilenameFromUrl(this.url?.toString());
             this.filename = filename;
 
-            const pdfDocument = await getDocument({
+            const pdfDocumentLoader = getDocument({
                 url: this.url,
                 isEvalSupported: false
-            }).promise;
+            });
+
+            const pdfDocument = await pdfDocumentLoader.promise;
 
             this.document = pdfDocument;
             this.viewer.setDocument(this.document);

--- a/packages/core/PDFSlick.ts
+++ b/packages/core/PDFSlick.ts
@@ -1,4 +1,5 @@
 import {
+    type OnProgressParameters
     GlobalWorkerOptions,
     getDocument,
     getPdfFilenameFromUrl,
@@ -239,7 +240,10 @@ export class PDFSlick {
         this.store.setState({ scaleValue });
     }
 
-    async loadDocument(url: string | URL | ArrayBuffer, options?: { filename?: string }) {
+    async loadDocument(
+      url: string | URL | ArrayBuffer,
+      options?: { filename?: string; onProgress?: (_: OnProgressParameters) => void; },
+    ) {
         if (this.url && typeof this.url === "string") {
             try {
                 URL.revokeObjectURL(this.url);
@@ -266,6 +270,10 @@ export class PDFSlick {
                 url: this.url,
                 isEvalSupported: false
             });
+
+            if (!!options.onProgress) {
+              pdfDocumentLoader.onProgress = options.onProgress;
+            }
 
             const pdfDocument = await pdfDocumentLoader.promise;
 


### PR DESCRIPTION
One can now configure the `loadDocument` call with a callback that reports the loading state.

Resolves #66
