### PR TITLE
added additional params for getDocument to options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16698,7 +16698,7 @@
     },
     "packages/core": {
       "name": "@pdfslick/core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "pdfjs-dist": "^4.10.38",
@@ -16766,10 +16766,10 @@
     },
     "packages/react": {
       "name": "@pdfslick/react",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@pdfslick/core": "^2.0.0",
+        "@pdfslick/core": "^2.0.1",
         "react-use": "^17.6.0",
         "tailwindcss": "^3.4.17",
         "vite": "^5.4.13",
@@ -16807,10 +16807,10 @@
     },
     "packages/solid": {
       "name": "@pdfslick/solid",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@pdfslick/core": "^2.0.0",
+        "@pdfslick/core": "^2.0.1",
         "@solid-primitives/resize-observer": "^2.1.0",
         "tailwindcss": "^3.4.17",
         "vite": "^5.4.13",
@@ -19189,7 +19189,7 @@
     "@pdfslick/react": {
       "version": "file:packages/react",
       "requires": {
-        "@pdfslick/core": "^2.0.0",
+        "@pdfslick/core": "^2.0.1",
         "@types/react": "^18.3.5",
         "concurrently": "^9.1.2",
         "copyfiles": "^2.4.1",
@@ -19244,7 +19244,7 @@
         "@babel/core": "^7.26.7",
         "@babel/preset-env": "^7.26.7",
         "@babel/preset-typescript": "^7.26.0",
-        "@pdfslick/core": "^2.0.0",
+        "@pdfslick/core": "^2.0.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@solid-primitives/resize-observer": "^2.1.0",

--- a/packages/core/PDFSlick.ts
+++ b/packages/core/PDFSlick.ts
@@ -14,6 +14,7 @@ import {
     UnexpectedResponseException,
     AnnotationEditorParamsType
 } from "pdfjs-dist";
+import type { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 import {
     EventBus,
     PDFViewer,
@@ -122,6 +123,7 @@ export class PDFSlick {
     maxCanvasPixels: number;
     printResolution: number;
     thumbnailWidth: number;
+    getDocumentParams: DocumentInitParameters;
 
     #onError: ((err: PDFException) => void) | undefined;
 
@@ -131,7 +133,7 @@ export class PDFSlick {
         thumbs,
         store = createStore(),
         options,
-        onError
+        onError,
     }: PDFSlickInputArgs) {
         this.#container = container;
         this.#viewerContainer = viewer;
@@ -155,6 +157,7 @@ export class PDFSlick {
         this.maxCanvasPixels = options?.maxCanvasPixels ?? 16777216;
         this.printResolution = options?.printResolution ?? 96;
         this.thumbnailWidth = options?.thumbnailWidth ?? 125;
+        this.getDocumentParams = options?.getDocumentParams ?? {};
 
         if (
             this.pageColors &&
@@ -263,6 +266,7 @@ export class PDFSlick {
             this.filename = filename;
 
             const pdfDocument = await getDocument({
+                ...this.getDocumentParams,
                 url: this.url,
                 isEvalSupported: false
             }).promise;

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -2,6 +2,7 @@ import { PDFViewer } from "pdfjs-dist/web/pdf_viewer.mjs";
 import { StoreApi } from "zustand";
 import { PDFSlick, type PDFException } from "./PDFSlick";
 import { PDFThumbnailView } from "./lib";
+import type { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 
 export type TPDFDocumentOutline = {
   title: string;
@@ -112,6 +113,7 @@ export type PDFSlickOptions = {
   thumbnailWidth?: number;
   scaleValue?: string;
   filename?: string;
+  getDocumentParams?: DocumentInitParameters;
 };
 
 export type PDFSlickInputArgs = {


### PR DESCRIPTION
Hey hey, thank you for your library!

In this PR I added additional options for `getDocument` function to pass credentials/httpHeaders to enable custom auth flow and services like Firebase AppCheck