### PR TITLE
chore(core): migrate pdfjs-dist to v6 (^6.0.227)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3923,9 +3923,9 @@
       }
     },
     "node_modules/@napi-rs/canvas": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.82.tgz",
-      "integrity": "sha512-FGjyUBoF0sl1EenSiE4UV2WYu76q6F9GSYedq5EiOCOyGYoQ/Owulcv6rd7v/tWOpljDDtefXXIaOCJrVKem4w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-1.0.0.tgz",
+      "integrity": "sha512-Jqxcy1XOIqj+lH9sl1GT+il6GR3uQv13vI2mrwubP3uT8Olak2ClDrK2RnxlQKjwv8BRr4b3ug0YR7c6hBX8wg==",
       "license": "MIT",
       "optional": true,
       "workspaces": [
@@ -3934,23 +3934,28 @@
       "engines": {
         "node": ">= 10"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
       "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.82",
-        "@napi-rs/canvas-darwin-arm64": "0.1.82",
-        "@napi-rs/canvas-darwin-x64": "0.1.82",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.82",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.82",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.82",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.82",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.82",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.82",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.82"
+        "@napi-rs/canvas-android-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-arm64": "1.0.0",
+        "@napi-rs/canvas-darwin-x64": "1.0.0",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.0",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.0",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.0",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.0",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.82.tgz",
-      "integrity": "sha512-bvZhN0iI54ouaQOrgJV96H2q7J3ZoufnHf4E1fUaERwW29Rz4rgicohnAg4venwBJZYjGl5Yl3CGmlAl1LZowQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-3hNKJObUK7JsCF9aJlVCs1J0/KE/gGfZNeK8MO1ge6bB3aicr5walGme9t9No1f/oyk9GgvdAT/rjSdsx3gbIw==",
       "cpu": [
         "arm64"
       ],
@@ -3961,12 +3966,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.82.tgz",
-      "integrity": "sha512-InuBHKCyuFqhNwNr4gpqazo5Xp6ltKflqOLiROn4hqAS8u21xAHyYCJRgHwd+a5NKmutFTaRWeUIT/vxWbU/iw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-ZIja19/BiGz2puhki+WUYSRriwFeFJ8Mi9eK3hZdSS85w4Y60cuEAJVhMCfKwswQkKkUtrnzdKMBuO7TupvexA==",
       "cpu": [
         "arm64"
       ],
@@ -3977,12 +3986,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.82.tgz",
-      "integrity": "sha512-aQGV5Ynn96onSXcuvYb2y7TRXD/t4CL2EGmnGqvLyeJX1JLSNisKQlWN/1bPDDXymZYSdUqbXehj5qzBlOx+RQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-hImggWc82jqZVpEsFR9S7PE9OQYjq/H/D7vwCGB6X1jRH+UVBP1+1niJTPBOat1B154T6GKK7/kcFtoWgjgFzQ==",
       "cpu": [
         "x64"
       ],
@@ -3993,12 +4006,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.82.tgz",
-      "integrity": "sha512-YIUpmHWeHGGRhWitT1KJkgj/JPXPfc9ox8oUoyaGPxolLGPp5AxJkq8wIg8CdFGtutget968dtwmx71m8o3h5g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-hlJRy6d+kWLKVOG/+1rEvNQVURZ0DxxRPJsLmEWwhwiXZUJc0BF5o9esALHSEP4CoJK4wChRtj3hnyBgVx2oWA==",
       "cpu": [
         "arm"
       ],
@@ -4009,12 +4026,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.82.tgz",
-      "integrity": "sha512-AwLzwLBgmvk7kWeUgItOUor/QyG31xqtD26w1tLpf4yE0hiXTGp23yc669aawjB6FzgIkjh1NKaNS52B7/qEBQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-5Hru4T3RXkosRQafcjelv7AUzw9mXqmGYsxnzeDDOWveFCJyEPMSJltvGCM+jfH98seOCbfwm9KyFg6Jm5FhAA==",
       "cpu": [
         "arm64"
       ],
@@ -4025,12 +4046,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.82.tgz",
-      "integrity": "sha512-moZWuqepAwWBffdF4JDadt8TgBD02iMhG6I1FHZf8xO20AsIp9rB+p0B8Zma2h2vAF/YMjeFCDmW5un6+zZz9g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
       ],
@@ -4041,12 +4066,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.82.tgz",
-      "integrity": "sha512-w9++2df2kG9eC9LWYIHIlMLuhIrKGQYfUxs97CwgxYjITeFakIRazI9LYWgVzEc98QZ9x9GQvlicFsrROV59MQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Iz931SAZf+WVDzpjk52Q3ffW3zw0YflFwEZMgs036Wfu1kX/LrwT9wGjsuSqyduqefUkl91/vTdAjn8hQu5ezA==",
       "cpu": [
         "riscv64"
       ],
@@ -4057,12 +4086,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.82.tgz",
-      "integrity": "sha512-lZulOPwrRi6hEg/17CaqdwWEUfOlIJuhXxincx1aVzsVOCmyHf+xFq4i6liJl1P+x2v6Iz2Z/H5zHvXJCC7Bwg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-pFEQ5eFK4JusgN1K6KkO9DKP/Hi1WMJOkF8Ch03/khTc4bFbCKkCCsJG4YcOMOW9bI4XbT2/eMAWxhO0xaWgPA==",
       "cpu": [
         "x64"
       ],
@@ -4073,12 +4106,16 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.82.tgz",
-      "integrity": "sha512-Be9Wf5RTv1w6GXlTph55K3PH3vsAh1Ax4T1FQY1UYM0QfD0yrwGdnJ8/fhqw7dEgMjd59zIbjJQC8C3msbGn5g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
       "cpu": [
         "x64"
       ],
@@ -4089,12 +4126,36 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-y2j9/Gfd5joqiqxdP/L1smqjQ+uAx3C4N0EC7bDHrnZEEH8ToM/OC5p3uHvtj4Lq591aHj+ArL01UDLNwT5HgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.82",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.82.tgz",
-      "integrity": "sha512-LN/i8VrvxTDmEEK1c10z2cdOTkWT76LlTGtyZe5Kr1sqoSomKeExAjbilnu1+oee5lZUgS5yfZ2LNlVhCeARuw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-qwdhh9N6Gge/hC4pL9S1tQp0iKwhSl/dYjg7+RGp9k26iRGRi5MqqUyKGOXIWli0zOcuy5Y2wIH/jk2ry6i/jA==",
       "cpu": [
         "x64"
       ],
@@ -4105,6 +4166,10 @@
       ],
       "engines": {
         "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -12418,15 +12483,15 @@
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.4.394",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.394.tgz",
-      "integrity": "sha512-9ariAYGqUJzx+V/1W4jHyiyCep6IZALmDzoaTLZ6VNu8q9LWi1/ukhzHgE2Xsx96AZi0mbZuK4/ttIbqSbLypg==",
+      "version": "6.0.227",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
+      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
+        "node": ">=22.13.0 || >=24"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.81"
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -16913,7 +16978,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "pdfjs-dist": "^5.4.394",
+        "pdfjs-dist": "^6.0.227",
         "zustand": "^5.0.8"
       },
       "devDependencies": {

--- a/packages/core/PDFSlick.ts
+++ b/packages/core/PDFSlick.ts
@@ -25,7 +25,7 @@ import {
     PDFSinglePageViewer
 } from "pdfjs-dist/web/pdf_viewer.mjs";
 
-import { IL10n, PDFViewerOptions } from "pdfjs-dist/types/web/pdf_viewer";
+import { L10n, PDFViewerOptions } from "pdfjs-dist/types/web/pdf_viewer";
 import type {
     TEventBusEvent,
     PDFSlickInputArgs,
@@ -109,7 +109,7 @@ export class PDFSlick {
     // options
     #annotationMode: number;
     #annotationEditorMode: number;
-    l10n: IL10n;
+    l10n: L10n;
     singlePageViewer: boolean;
     removePageBorders: boolean;
     enablePrintAutoRotate: boolean;
@@ -213,7 +213,6 @@ export class PDFSlick {
             annotationEditorMode: this.#annotationEditorMode,
             removePageBorders: this.removePageBorders,
             imageResourcesPath: "/images/",
-            enableHWA: this.enableHWA,
             enableDetailCanvas: this.enableDetailCanvas,
             enableOptimizedPartialRendering: this.enableOptimizedPartialRendering,
             minDurationToUpdateCanvas: this.minDurationToUpdateCanvas,
@@ -282,7 +281,9 @@ export class PDFSlick {
         }
 
         try {
-            this.document?.destroy();
+            // `PDFDocumentProxy.destroy()` was removed in pdfjs-dist v6; tear
+            // down the previous document through its loading task instead.
+            this.document?.loadingTask.destroy();
             this.viewer?.cleanup();
 
             if (url instanceof URL) {
@@ -299,7 +300,7 @@ export class PDFSlick {
             const pdfDocumentLoader = getDocument({
                 ...this.getDocumentParams,
                 url: this.url,
-                isEvalSupported: false
+                enableHWA: this.enableHWA,
             });
 
             if (!!options?.onProgress) {
@@ -469,15 +470,23 @@ export class PDFSlick {
 
         const [{ width, height }, unit, name, orientation] = await Promise.all([
             _isNonMetricLocale ? sizeInches : sizeMillimeters,
+            // pdfjs-dist v6 `L10n.get(ids, args, fallback)` requires a fallback
+            // value, which is returned when the id isn't in the l10n bundle.
             this.l10n.get(
-                `document_properties_page_size_unit_${_isNonMetricLocale ? "inches" : "millimeters"}`, null
+                `document_properties_page_size_unit_${_isNonMetricLocale ? "inches" : "millimeters"}`,
+                null,
+                _isNonMetricLocale ? "in" : "mm"
             ),
             rawName &&
             this.l10n.get(
-                `document_properties_page_size_name_${rawName.toLowerCase()}`, null
+                `document_properties_page_size_name_${rawName.toLowerCase()}`,
+                null,
+                rawName
             ),
             this.l10n.get(
-                `document_properties_page_size_orientation_${isPortrait ? "portrait" : "landscape"}`, null
+                `document_properties_page_size_orientation_${isPortrait ? "portrait" : "landscape"}`,
+                null,
+                isPortrait ? "portrait" : "landscape"
             ),
         ]);
 
@@ -510,18 +519,18 @@ export class PDFSlick {
     async download() {
         const url = this.url;
         const { filename } = this;
+        let data: Uint8Array | undefined;
         try {
             // this._ensureDownloadComplete();
-
-            const data = (await this.document!.getData()).slice(0);
-            const blob = new Blob([data], { type: "application/pdf" });
-
-            await this.downloadManager?.download(blob, url, filename);
-        } catch (reason) {
+            data = (await this.document!.getData()).slice(0);
+        } catch {
             // When the PDF document isn't ready, or the PDF file is still
             // downloading, simply download using the URL.
-            await this.downloadManager?.download(null, url, filename);
         }
+        // As of pdfjs-dist v6, `download` takes the raw document data (a
+        // `Uint8Array`) and builds the blob internally; a falsy `data` makes
+        // it fall back to downloading directly from the URL.
+        await this.downloadManager?.download(data!, url as string, filename);
     }
 
     async save() {
@@ -535,9 +544,8 @@ export class PDFSlick {
             // this._ensureDownloadComplete();
 
             const data = (await this.document!.saveDocument()).slice(0);
-            const blob = new Blob([data], { type: "application/pdf" });
 
-            await this.downloadManager?.download(blob, url, filename);
+            await this.downloadManager?.download(data, url as string, filename);
         } catch (reason: any) {
             // When the PDF document isn't ready, or the PDF file is still
             // downloading, simply fallback to a "regular" download.
@@ -582,13 +590,13 @@ export class PDFSlick {
         const { signal } = this.#eventAbortController;
         const opts: any = { signal };
 
-        this.eventBus._on("pagesinit", this.#onDocumentReady.bind(this), opts);
-        this.eventBus._on("scalechanging", this.#onScaleChanging.bind(this), opts);
-        this.eventBus._on("pagechanging", this.#onPageChanging.bind(this), opts);
-        this.eventBus._on("pagerendered", this.#onPageRendered.bind(this), opts);
-        this.eventBus._on("rotationchanging", this.#onRotationChanging.bind(this), opts);
-        this.eventBus._on("switchspreadmode", this.#onSwitchSpreadMode.bind(this), opts);
-        this.eventBus._on("switchscrollmode", this.#onSwitchScrollMode.bind(this), opts);
+        this.eventBus.on("pagesinit", this.#onDocumentReady.bind(this), opts);
+        this.eventBus.on("scalechanging", this.#onScaleChanging.bind(this), opts);
+        this.eventBus.on("pagechanging", this.#onPageChanging.bind(this), opts);
+        this.eventBus.on("pagerendered", this.#onPageRendered.bind(this), opts);
+        this.eventBus.on("rotationchanging", this.#onRotationChanging.bind(this), opts);
+        this.eventBus.on("switchspreadmode", this.#onSwitchSpreadMode.bind(this), opts);
+        this.eventBus.on("switchscrollmode", this.#onSwitchScrollMode.bind(this), opts);
     }
 
     unbindEvents() {

--- a/packages/core/PDFSlickPrintService.ts
+++ b/packages/core/PDFSlickPrintService.ts
@@ -104,7 +104,11 @@ export class PDFSlickPrintService {
         // The beforePrint is a sync method and we need to know layout before
         // returning from this method. Ensure that we can get sizes of the pages.
         if (!this.slick.viewer.pageViewsReady) {
-            this.slick.l10n.get("printing_not_ready", null).then((msg) => {
+            this.slick.l10n.get(
+                "printing_not_ready",
+                null,
+                "Warning: The PDF is not fully loaded for printing."
+            ).then((msg) => {
                 // eslint-disable-next-line no-alert
                 window.alert(msg);
             });
@@ -145,8 +149,8 @@ export class PDFSlickPrintService {
         const { signal } = this.#eventAbortController;
         const opts: any = { signal };
 
-        this.eventBus._on("beforeprint", this.#beforePrint.bind(this), opts);
-        this.eventBus._on("afterprint", this.#afterPrint.bind(this), opts);
+        this.eventBus.on("beforeprint", this.#beforePrint.bind(this), opts);
+        this.eventBus.on("afterprint", this.#afterPrint.bind(this), opts);
 
         window.addEventListener(
             "beforeprint",

--- a/packages/core/lib/pdf_print_service.ts
+++ b/packages/core/lib/pdf_print_service.ts
@@ -17,7 +17,7 @@ import {
   AnnotationMode,
   PixelsPerInch,
   RenderingCancelledException,
-  getXfaPageViewport,
+  XfaLayer,
   PDFDocumentProxy,
   PDFPageProxy,
 } from "pdfjs-dist";
@@ -49,7 +49,7 @@ function getXfaHtmlForPrinting(
       linkService,
       xfaHtml: xfaPage,
     });
-    const viewport = getXfaPageViewport(xfaPage, { scale });
+    const viewport = XfaLayer.getPageViewport(xfaPage, { scale });
 
     builder.render({ viewport, intent: "print" });
     page.append(builder.div!);

--- a/packages/core/lib/pdf_rendering_queue.ts
+++ b/packages/core/lib/pdf_rendering_queue.ts
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-/** @typedef {import("./interfaces").IRenderableView} IRenderableView */
+/** @typedef {import("./interfaces").RenderableView} RenderableView */
 /** @typedef {import("./pdf_viewer").PDFViewer} PDFViewer */
 /** @typedef {import("./pdf_thumbnail_viewer").PDFThumbnailViewer} PDFThumbnailViewer */
 
 import { RenderingCancelledException } from "pdfjs-dist";
-import { IRenderableView } from "pdfjs-dist/types/web/interfaces.js";
+import { RenderableView } from "pdfjs-dist/types/web/renderable_view";
 import { PDFThumbnailViewer } from "./pdf_thumbnail_viewer";
 
 import { PDFViewer } from "pdfjs-dist/web/pdf_viewer.mjs";
@@ -70,10 +70,10 @@ class PDFRenderingQueue {
   }
 
   /**
-   * @param {IRenderableView} view
+   * @param {RenderableView} view
    * @returns {boolean}
    */
-  isHighestPriority(view: IRenderableView) {
+  isHighestPriority(view: RenderableView) {
     return this.highestPriorityPage === view.renderingId;
   }
 
@@ -115,14 +115,14 @@ class PDFRenderingQueue {
    * @param {boolean} [preRenderExtra]
    */
   getHighestPriority<
-    T extends { div: HTMLElement; id: number; detailView?: IRenderableView } & IRenderableView
+    T extends { div: HTMLElement; id: number; detailView?: RenderableView } & RenderableView
   >(
     visible: ReturnType<typeof getVisibleElements<T>>,
     views: T[],
     scrolledDown: boolean,
     preRenderExtra = false,
     ignoreDetailViews = false
-  ): IRenderableView | null {
+  ): RenderableView | null {
     /**
      * The state has changed. Figure out which page has the highest priority to
      * render next (if any).
@@ -195,10 +195,10 @@ class PDFRenderingQueue {
   }
 
   /**
-   * @param {IRenderableView} view
+   * @param {RenderableView} view
    * @returns {boolean}
    */
-  isViewFinished(view: IRenderableView) {
+  isViewFinished(view: RenderableView) {
     return view.renderingState === RenderingStates.FINISHED;
   }
 
@@ -207,9 +207,9 @@ class PDFRenderingQueue {
    * based on the views state. If the view is already rendered it will return
    * `false`.
    *
-   * @param {IRenderableView} view
+   * @param {RenderableView} view
    */
-  renderView(view: IRenderableView) {
+  renderView(view: RenderableView) {
     switch (view.renderingState) {
       case RenderingStates.FINISHED:
         return false;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "css-watch-js": "npm run css -- --watch"
   },
   "dependencies": {
-    "pdfjs-dist": "^5.4.394",
+    "pdfjs-dist": "^6.0.227",
     "zustand": "^5.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade @pdfslick/core from pdfjs-dist ^5.4.394 to ^6.0.227 and adapt to the v6 breaking changes. All pdfjs usage is in packages/core; the react and solid packages depend only on @pdfslick/core and needed no source changes.

Breaking changes handled (see mozilla/pdf.js v6.0.227 release notes):

- getXfaPageViewport moved into the XfaLayer class -> use XfaLayer.getPageViewport, imported from the main pdfjs-dist entry.
- PDFDocumentProxy.destroy() removed -> tear down the previous document via document.loadingTask.destroy().
- getDocument() no longer accepts isEvalSupported -> option dropped.
- enableHWA removed from PDFViewerOptions and is now a getDocument parameter -> moved it from the viewer options to getDocument().
- DownloadManager.download(data, url, filename) now takes a raw Uint8Array and builds the Blob internally (falsy data falls back to the URL) -> download()/save() pass the Uint8Array directly.
- EventBus._on removed; public on(name, listener, { signal }) now honors the abort signal -> replaced _on with on.
- L10n.get(ids, args, fallback) now requires a fallback argument and the IL10n type is renamed L10n -> added fallbacks and updated the type import.
- web/interfaces.js removed and IRenderableView renamed RenderableView in web/renderable_view -> updated import path and identifier.

Worker (build/pdf.worker.min.mjs) and CSS (web/pdf_viewer.css) paths are unchanged in v6, so the worker URL and CSS build step were left as-is. The public PDFSlick API is unchanged