### PR TITLE
fix: sync package-lock with package.json so npm ci passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,14 +163,6 @@
         "typescript": "5.7.3"
       }
     },
-    "apps/web/node_modules/@types/node": {
-      "version": "22.19.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "config/eslint-config-custom": {
       "version": "0.0.0",
       "license": "MIT",
@@ -2287,9 +2279,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260606.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260606.1.tgz",
-      "integrity": "sha512-0FFUsixapowVJcAjRlXLb6UEZG1caUlSuUX1KHhKgWgjKxq20dY5XeCS5lKPqgc80XJ9puwffJ2H1U6Fwr5N1g==",
+      "version": "4.20260607.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260607.1.tgz",
+      "integrity": "sha512-TSiusluJ8+5esTMYwxGFuT1SNU/PRzPmt9VMsmAlzjIK0mhc24Zsc1bbGEVH5qyMZ8hrdRtrAPdt2+T8Vph2+Q==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -6436,10 +6428,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.6",
@@ -15847,6 +15842,12 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "serialize-javascript": "^7.0.5",
     "js-cookie": "^3.0.8",
     "cookie": "^0.7.2",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "@types/node": "^22"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
## Problem

`npm ci` fails in CI with the lockfile out of sync:

```
npm error Invalid: lock file's @types/node@12.20.55 does not satisfy @types/node@25.9.2
npm error Missing: @types/node@12.20.55 from lock file
npm error Missing: undici-types@7.24.6 from lock file
npm error Missing: undici-types@6.21.0 from lock file
```

## Root cause

The committed lockfile's hoisted top-level `@types/node` was pinned to **12.20.55** — dragged in by `@manypkg/find-root`'s `^12.7.1` (a transitive dep of `@changesets/cli`). `npm install` is lenient and tolerated this, but `npm ci` is strict: it rebuilds the ideal tree, sees that `vite` peer-requires `@types/node` `>=22` (and `@types/fs-extra` / `@types/glob` require `*`), so it must hoist a `>=22`-satisfying version — the latest, **25.9.2** (with `undici-types@7.24.6`) — which the committed lock didn't contain. Hence the `EUSAGE` "out of sync" error.

This inconsistent lock was introduced by #126 (which wholesale-regenerated `package-lock.json` and first added the `overrides` block).

## Fix

- **`package.json`** — add `"@types/node": "^22"` to the existing `overrides` so every transitive `@types/node` resolves to a single v22 line, matching the project's Node 22 target (`.nvmrc` = 22, `engines.node >= 20`, `apps/web` pins `^22.13.5`) instead of floating to Node 25 typings.
- **`package-lock.json`** — regenerated under Node 22 / npm 11.6.2 (matching `.nvmrc` + the `packageManager` pin). `@types/node` now resolves to one hoisted `22.19.20`, `undici-types@6.21.0` is recorded, and `apps/web`'s redundant nested copy dedupes away. Surgical diff (~31 lines).

## Verification

- `npm ci` → **exit 0**, no `EUSAGE`.
- `npm ls @types/node` → every entry deduped to **22.19.20** (satisfies vite's peer, `apps/web`'s `^22.13.5`, and the `*` consumers).
- `@pdfslick/{core,react,solid}` build clean (incl. TS declaration emit) — no type regressions.
- Lockfile is valid JSON and fully hermetic (all `resolved`/`integrity` present).

> Note: regenerated with `--legacy-peer-deps` due to a **pre-existing, unrelated** peer conflict (`@kobalte/tailwindcss@0.9.0` wants `tailwindcss@^3`, but `apps/solidweb` is on v4). This only affects lock *generation*; CI's plain `npm ci` installs from the lock and is unaffected.