### PR TITLE
Publish v4.0.0

### DIFF
--- a/.changeset/remove-react-use-dependency.md
+++ b/.changeset/remove-react-use-dependency.md
@@ -1,5 +1,0 @@
----
-"@pdfslick/react": patch
----
-
-Remove the `react-use` runtime dependency. `useMeasure` and `useDebounce` are now implemented locally (`ResizeObserver` + `setTimeout`), eliminating the transitive `js-cookie` advisory (GHSA-qjx8-664m-686j) for consumers and dropping several transitive dependencies. No public API change.

--- a/apps/solidweb/CHANGELOG.md
+++ b/apps/solidweb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # solidweb
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @pdfslick/solid@4.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/apps/solidweb/package.json
+++ b/apps/solidweb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solidweb",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "private": true,
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@kobalte/core": "^0.13.9",
-    "@pdfslick/solid": "^3.0.0",
+    "@pdfslick/solid": "^4.0.0",
     "@solid-primitives/resize-observer": "^2.1.0",
     "d3-drag": "^3.0.0",
     "d3-selection": "^3.0.0",

--- a/apps/svelteweb/CHANGELOG.md
+++ b/apps/svelteweb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # svelteweb
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @pdfslick/core@4.0.0
+
 ## 0.0.3
 
 ### Patch Changes

--- a/apps/svelteweb/package.json
+++ b/apps/svelteweb/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelteweb",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",
@@ -38,7 +38,7 @@
 		"wrangler": "^4.98.0"
 	},
 	"dependencies": {
-		"@pdfslick/core": "^3.0.0",
+		"@pdfslick/core": "^4.0.0",
 		"@tailwindcss/postcss": "^4.0.9",
 		"d3-drag": "^3.0.0",
 		"d3-selection": "^3.0.0",

--- a/apps/vanillajs/CHANGELOG.md
+++ b/apps/vanillajs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vanillajs
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @pdfslick/core@4.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/apps/vanillajs/package.json
+++ b/apps/vanillajs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vanillajs",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -16,6 +16,6 @@
     "vite": "^6.2.0"
   },
   "dependencies": {
-    "@pdfslick/core": "^3.0.0"
+    "@pdfslick/core": "^4.0.0"
   }
 }

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # web
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [9f1a419]
+- Updated dependencies
+  - @pdfslick/react@4.0.0
+  - @pdfslick/core@4.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
@@ -13,8 +13,8 @@
     "@heroicons/react": "^2.2.0",
     "@markdoc/markdoc": "^0.5.4",
     "@markdoc/next.js": "^0.5.0",
-    "@pdfslick/core": "^3.0.0",
-    "@pdfslick/react": "^3.0.0",
+    "@pdfslick/core": "^4.0.0",
+    "@pdfslick/react": "^4.0.0",
     "@radix-ui/react-popover": "^1.1.6",
     "@sindresorhus/slugify": "^2.2.1",
     "@tabler/icons-react": "^3.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,11 @@
       }
     },
     "apps/solidweb": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@kobalte/core": "^0.13.9",
-        "@pdfslick/solid": "^3.0.0",
+        "@pdfslick/solid": "^4.0.0",
         "@solid-primitives/resize-observer": "^2.1.0",
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -65,9 +65,9 @@
       }
     },
     "apps/svelteweb": {
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
-        "@pdfslick/core": "^3.0.0",
+        "@pdfslick/core": "^4.0.0",
         "@tailwindcss/postcss": "^4.0.9",
         "d3-drag": "^3.0.0",
         "d3-selection": "^3.0.0",
@@ -103,9 +103,9 @@
       }
     },
     "apps/vanillajs": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
-        "@pdfslick/core": "^3.0.0"
+        "@pdfslick/core": "^4.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.9",
@@ -116,14 +116,14 @@
       }
     },
     "apps/web": {
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
         "@markdoc/markdoc": "^0.5.4",
         "@markdoc/next.js": "^0.5.0",
-        "@pdfslick/core": "^3.0.0",
-        "@pdfslick/react": "^3.0.0",
+        "@pdfslick/core": "^4.0.0",
+        "@pdfslick/react": "^4.0.0",
         "@radix-ui/react-popover": "^1.1.6",
         "@sindresorhus/slugify": "^2.2.1",
         "@tabler/icons-react": "^3.30.0",
@@ -280,6 +280,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2321,27 +2322,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3876,6 +3856,7 @@
       "resolved": "https://registry.npmjs.org/@markdoc/markdoc/-/markdoc-0.5.7.tgz",
       "integrity": "sha512-NxreNThm7foFgMMQD6zgk7rKkcFMmdC8J5r+Zn4FKoN75F5YjvwdihwF11VhrBfL3CXnD4+YG1VYwvBL+igzvw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.7.0"
       },
@@ -5704,6 +5685,7 @@
       "integrity": "sha512-1DrR7vQ9brXLrNE2sLtFXApwr7AUXPfpbIFYc+CQRf2+iURaZbXGU+7TG/RLr+9fdFkoRdyCAVUOHCChw11LFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.9",
@@ -5756,6 +5738,7 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -6194,7 +6177,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6208,7 +6190,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6222,7 +6203,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6236,7 +6216,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6250,7 +6229,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6264,7 +6242,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6432,6 +6409,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
       "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6446,15 +6424,16 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -6464,8 +6443,9 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -6526,6 +6506,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -6628,6 +6609,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
       "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -7017,6 +6999,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7655,6 +7638,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8250,6 +8234,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8912,6 +8897,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9133,6 +9119,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11015,6 +11002,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -11202,6 +11190,7 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -12247,6 +12236,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
       "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.19",
         "@swc/helpers": "0.5.15",
@@ -13175,6 +13165,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -13584,6 +13575,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13712,6 +13704,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13745,6 +13738,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -14167,6 +14161,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -14507,6 +14502,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -14792,6 +14788,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.13.tgz",
       "integrity": "sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -15185,6 +15182,7 @@
       "integrity": "sha512-1lDf8TLqpxyAt3xgybfytWPJQbaUD6TiDgpiCLH0BKrKEwzecB9pjuNVnEJMpzH018xUzo6oxheK2HT0oa2RoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -15420,7 +15418,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -15463,6 +15462,7 @@
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15626,6 +15626,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15696,14 +15697,15 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turbo": {
       "version": "2.9.16",
       "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.9.16.tgz",
       "integrity": "sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "turbo": "bin/turbo"
       },
@@ -15807,6 +15809,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15855,6 +15858,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -16074,6 +16078,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -16391,6 +16396,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -16425,6 +16431,7 @@
       "integrity": "sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
@@ -17146,7 +17153,7 @@
     },
     "packages/core": {
       "name": "@pdfslick/core",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "pdfjs-dist": "^6.0.227",
@@ -17180,10 +17187,10 @@
     },
     "packages/react": {
       "name": "@pdfslick/react",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@pdfslick/core": "^3.1.0",
+        "@pdfslick/core": "^4.0.0",
         "use-sync-external-store": "^1.6.0"
       },
       "devDependencies": {
@@ -17218,10 +17225,10 @@
     },
     "packages/solid": {
       "name": "@pdfslick/solid",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@pdfslick/core": "^3.1.0",
+        "@pdfslick/core": "^4.0.0",
         "@solid-primitives/resize-observer": "^2.1.3"
       },
       "devDependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pdfslick/core
 
+## 4.0.0
+
+### Major Changes
+
+- Update to pdfjs v6
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdfslick/core",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "source": "./index.ts",
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pdfslick/react
 
+## 4.0.0
+
+### Major Changes
+
+- Update to pdfjs v6
+
+### Patch Changes
+
+- Remove the `react-use` runtime dependency. `useMeasure` and `useDebounce` are now implemented locally (`ResizeObserver` + `setTimeout`), eliminating the transitive `js-cookie` advisory (GHSA-qjx8-664m-686j) for consumers and dropping several transitive dependencies. No public API change.
+- Updated dependencies
+  - @pdfslick/core@4.0.0
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdfslick/react",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "source": "./index.tsx",
   "main": "dist/umd/index.js",
   "module": "dist/esm/index.js",
@@ -61,7 +61,7 @@
     "react-dom": ">=17"
   },
   "dependencies": {
-    "@pdfslick/core": "^3.1.0",
+    "@pdfslick/core": "^4.0.0",
     "use-sync-external-store": "^1.6.0"
   },
   "publishConfig": {

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pdfslick/solid
 
+## 4.0.0
+
+### Major Changes
+
+- Update to pdfjs v6
+
+### Patch Changes
+
+- Updated dependencies
+  - @pdfslick/core@4.0.0
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pdfslick/solid",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "source": "./index.tsx",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -71,7 +71,7 @@
     "solid-js": ">=1.5.0"
   },
   "dependencies": {
-    "@pdfslick/core": "^3.1.0",
+    "@pdfslick/core": "^4.0.0",
     "@solid-primitives/resize-observer": "^2.1.3"
   },
   "publishConfig": {


### PR DESCRIPTION
## Release: v4.0.0

Version-bump PR that prepares all three published packages for release. Merging this, then creating a GitHub Release `v4.0.0`, triggers the npm publish workflow.

### Versions
| Package | 3.1.0 → |
| --- | --- |
| `@pdfslick/core` | **4.0.0** |
| `@pdfslick/react` | **4.0.0** |
| `@pdfslick/solid` | **4.0.0** |

### What's in this release
- **Major — Update to pdfjs v6** (#125): `pdfjs-dist` 5.x → `^6.0.227`, with the accompanying `@pdfslick/core` source changes. Released as a major, matching the precedent set by the pdfjs v4→v5 migration (which was 2.3.0 → 3.0.0).
- **Patch (`@pdfslick/react`)** — Remove the `react-use` runtime dependency; `useMeasure`/`useDebounce` are now implemented locally, dropping the transitive `js-cookie` advisory (GHSA-qjx8-664m-686j) for consumers. No public API change.

### How this was prepared
- Added a changeset marking core/react/solid as `major` ("Update to pdfjs v6"); kept the existing react-use patch changeset.
- Ran `changeset version` (bumps versions, rewrites internal + demo-app `@pdfslick/*` ranges to `^4.0.0`, updates CHANGELOGs, consumes changesets).
- Ran `npm install` to sync `package-lock.json`.
- Verified `turbo run build` succeeds for all three packages with pdfjs v6.

### After merge
Create a GitHub Release `v4.0.0` (targeting `main`) to fire `publish_packages_to_npm.yml` → `npm ci` → `npm run build` → `changeset publish`, publishing the three packages to npm with provenance.
